### PR TITLE
Fix auto_switch with CSS variables theming

### DIFF
--- a/starlighter/themes.py
+++ b/starlighter/themes.py
@@ -1,5 +1,73 @@
 """Built-in CSS themes for Starlighter; concise APIs and minimal comments."""
 
+# Modern CSS Variables-based theming
+BASE_CSS_WITH_VARS = """
+/* Base syntax highlighting styles with CSS variables */
+.code-container {
+    background: var(--code-bg);
+    color: var(--code-color);
+    border: 1px solid var(--code-border);
+    border-radius: 8px;
+    padding: 20px;
+    overflow-x: auto;
+    margin: 0;
+    min-width: 0;
+    font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'SF Mono', monospace;
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+.code-container pre {
+    margin: 0;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: inherit;
+    white-space: pre;
+    overflow-x: auto;
+    min-width: 0;
+}
+
+.code-container code {
+    font-family: inherit;
+    background: none;
+    padding: 0;
+    display: block;
+    white-space: pre;
+    overflow-x: auto;
+}
+
+/* Token colors using CSS variables */
+.token-keyword { color: var(--token-keyword); }
+.token-string { color: var(--token-string); }
+.token-comment { color: var(--token-comment); font-style: italic; }
+.token-number { color: var(--token-number); }
+.token-operator { color: var(--token-operator); }
+.token-identifier { color: var(--token-identifier); }
+.token-builtin { color: var(--token-builtin); }
+.token-decorator { color: var(--token-decorator); }
+.token-punctuation { color: var(--token-punctuation); }
+
+/* Scrollbar styling */
+.code-container::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+}
+
+.code-container::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+}
+
+.code-container::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 4px;
+}
+
+.code-container::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+}
+"""
+
+# Legacy BASE_CSS for backward compatibility
 BASE_CSS = """
 /* Base syntax highlighting styles */
 .code-container {
@@ -271,6 +339,118 @@ def _build_all_css() -> str:
 
 ALL_THEMES_CSS = _build_all_css()
 
+# CSS Variables theme definitions
+THEME_VARS = {
+    "github-dark": {
+        "--code-bg": "#0d1117",
+        "--code-color": "#c9d1d9",
+        "--code-border": "#30363d",
+        "--token-keyword": "#ff7b72",
+        "--token-string": "#a5d6ff",
+        "--token-comment": "#8b949e",
+        "--token-number": "#79c0ff",
+        "--token-operator": "#c9d1d9",
+        "--token-identifier": "#d2a8ff",
+        "--token-builtin": "#ffa657",
+        "--token-decorator": "#d2a8ff",
+        "--token-punctuation": "#c9d1d9",
+        "--scrollbar-track": "#0d1117",
+        "--scrollbar-thumb": "#30363d",
+        "--scrollbar-thumb-hover": "#484f58",
+    },
+    "light": {
+        "--code-bg": "#ffffff",
+        "--code-color": "#333333",
+        "--code-border": "#e1e8ed",
+        "--token-keyword": "#0000ff",
+        "--token-string": "#a31515",
+        "--token-comment": "#008000",
+        "--token-number": "#098658",
+        "--token-operator": "#000000",
+        "--token-identifier": "#001080",
+        "--token-builtin": "#267f99",
+        "--token-decorator": "#795e26",
+        "--token-punctuation": "#000000",
+        "--scrollbar-track": "#f6f8fa",
+        "--scrollbar-thumb": "#d1d5da",
+        "--scrollbar-thumb-hover": "#a8b1bb",
+    },
+    "vscode": {
+        "--code-bg": "#1e1e1e",
+        "--code-color": "#d4d4d4",
+        "--code-border": "#4a5568",
+        "--token-keyword": "#569cd6",
+        "--token-string": "#ce9178",
+        "--token-comment": "#6a9955",
+        "--token-number": "#b5cea8",
+        "--token-operator": "#d4d4d4",
+        "--token-identifier": "#9cdcfe",
+        "--token-builtin": "#4ec9b0",
+        "--token-decorator": "#dcdcaa",
+        "--token-punctuation": "#d4d4d4",
+        "--scrollbar-track": "#1e1e1e",
+        "--scrollbar-thumb": "#4a5568",
+        "--scrollbar-thumb-hover": "#718096",
+    },
+    "monokai": {
+        "--code-bg": "#272822",
+        "--code-color": "#f8f8f2",
+        "--code-border": "#4a5568",
+        "--token-keyword": "#f92672",
+        "--token-string": "#e6db74",
+        "--token-comment": "#75715e",
+        "--token-number": "#ae81ff",
+        "--token-operator": "#f8f8f2",
+        "--token-identifier": "#a6e22e",
+        "--token-builtin": "#66d9ef",
+        "--token-decorator": "#f92672",
+        "--token-punctuation": "#f8f8f2",
+        "--scrollbar-track": "#272822",
+        "--scrollbar-thumb": "#4a5568",
+        "--scrollbar-thumb-hover": "#718096",
+    },
+    "dracula": {
+        "--code-bg": "#282a36",
+        "--code-color": "#f8f8f2",
+        "--code-border": "#44475a",
+        "--token-keyword": "#ff79c6",
+        "--token-string": "#f1fa8c",
+        "--token-comment": "#6272a4",
+        "--token-number": "#bd93f9",
+        "--token-operator": "#f8f8f2",
+        "--token-identifier": "#50fa7b",
+        "--token-builtin": "#8be9fd",
+        "--token-decorator": "#ff79c6",
+        "--token-punctuation": "#f8f8f2",
+        "--scrollbar-track": "#282a36",
+        "--scrollbar-thumb": "#44475a",
+        "--scrollbar-thumb-hover": "#6272a4",
+    },
+    "catppuccin": {
+        "--code-bg": "#1e1e2e",
+        "--code-color": "#cdd6f4",
+        "--code-border": "#45475a",
+        "--token-keyword": "#cba6f7",
+        "--token-string": "#a6e3a1",
+        "--token-comment": "#6c7086",
+        "--token-number": "#fab387",
+        "--token-operator": "#cdd6f4",
+        "--token-identifier": "#89dceb",
+        "--token-builtin": "#f9e2af",
+        "--token-decorator": "#f5c2e7",
+        "--token-punctuation": "#cdd6f4",
+        "--scrollbar-track": "#1e1e2e",
+        "--scrollbar-thumb": "#45475a",
+        "--scrollbar-thumb-hover": "#6c7086",
+    },
+}
+
+
+def _generate_css_vars_string(vars_dict):
+    """Generate CSS variable declarations from a dictionary."""
+    return "\n    ".join(f"{key}: {value};" for key, value in vars_dict.items())
+
+
 THEMES = {
     "vscode": "VS Code Dark+",
     "light": "VS Code Light+",
@@ -307,58 +487,77 @@ def _style_element(css_content: str, **kwargs):
     return Style(css_content, **kwargs)
 
 
-def StarlighterStyles(*themes, auto_switch: bool = False, **kwargs):
-    """Style element with base + requested themes. Optional dark/light auto-switch."""
+def StarlighterStyles(
+    *themes, auto_switch: bool = False, use_vars: bool = True, **kwargs
+):
+    """
+    Style element with base + requested themes.
+
+    Args:
+        *themes: Theme names to include. Defaults to ("github-dark",)
+        auto_switch: Enable automatic theme switching based on system preference
+        use_vars: Use CSS variables for theming (recommended for auto_switch)
+        **kwargs: Additional arguments passed to Style element
+    """
     if not themes:
         themes = ("github-dark",)
 
-    css_parts = [BASE_CSS]
+    # Use CSS variables approach when auto_switch is enabled or use_vars is True
+    if auto_switch or use_vars:
+        css_parts = [BASE_CSS_WITH_VARS]
 
-    # Add requested themes
-    for theme in themes:
-        if theme in THEME_CSS_MAP:
-            css_parts.append(THEME_CSS_MAP[theme])
-
-    # Auto-switch: system preference and explicit data-theme hooks
-    if auto_switch:
-        dark_theme = themes[0] if themes else "vscode"
+        # Determine default theme and optional light theme for auto-switching
+        default_theme = themes[0] if themes else "github-dark"
         light_theme = "light" if "light" in themes else None
 
-        if dark_theme in THEME_CSS_MAP:
-            dark_css = THEME_CSS_MAP[dark_theme]
-            # Dark theme is already added in the main themes loop,
-            # just add media query for explicit dark preference
+        # Set default theme variables (dark theme by default)
+        if default_theme in THEME_VARS:
             css_parts.append(f"""
-/* Dark theme for system preference */
-@media (prefers-color-scheme: dark) {{
-    {dark_css}
+/* Default theme: {default_theme} */
+:root {{
+    {_generate_css_vars_string(THEME_VARS[default_theme])}
 }}""")
 
-        if light_theme and light_theme in THEME_CSS_MAP:
-            light_css = THEME_CSS_MAP[light_theme]
-            # Add light theme with proper media query
+        # Add auto-switch support if requested
+        if auto_switch and light_theme and light_theme in THEME_VARS:
+            # Light theme for system preference
             css_parts.append(f"""
-/* Light theme for system preference */
+/* Auto-switch to light theme based on system preference */
 @media (prefers-color-scheme: light) {{
-    {light_css}
+    :root {{
+        {_generate_css_vars_string(THEME_VARS[light_theme])}
+    }}
+}}""")
+
+            # Manual theme overrides via data-theme attribute
+            css_parts.append(f"""
+/* Manual theme override: dark */
+[data-theme="dark"] {{
+    {_generate_css_vars_string(THEME_VARS[default_theme])}
 }}
 
-/* Light theme for explicit data-theme */
-[data-theme="light"] .code-container {{
-    background: #ffffff !important;
-    color: #333;
-    border-color: #e1e8ed;
-}}
+/* Manual theme override: light */
+[data-theme="light"] {{
+    {_generate_css_vars_string(THEME_VARS[light_theme])}
+}}""")
 
-[data-theme="light"] .token-keyword {{ color: #0000ff; }}
-[data-theme="light"] .token-string {{ color: #a31515; }}
-[data-theme="light"] .token-comment {{ color: #008000; font-style: italic; }}
-[data-theme="light"] .token-number {{ color: #098658; }}
-[data-theme="light"] .token-operator {{ color: #000000; }}
-[data-theme="light"] .token-identifier {{ color: #001080; }}
-[data-theme="light"] .token-builtin {{ color: #267f99; }}
-[data-theme="light"] .token-decorator {{ color: #795e26; }}
-[data-theme="light"] .token-punctuation {{ color: #000000; }}""")
+        # Add theme-specific class overrides for backward compatibility
+        for theme in themes:
+            if theme in THEME_VARS:
+                css_parts.append(f"""
+/* Theme class override: {theme} */
+.theme-{theme} {{
+    {_generate_css_vars_string(THEME_VARS[theme])}
+}}""")
+
+    else:
+        # Legacy approach: use class-based themes
+        css_parts = [BASE_CSS]
+
+        # Add requested themes
+        for theme in themes:
+            if theme in THEME_CSS_MAP:
+                css_parts.append(THEME_CSS_MAP[theme])
 
     return _style_element("\n".join(css_parts), **kwargs)
 


### PR DESCRIPTION
## Summary
- Replaced broken class-based theme switching with modern CSS variables
- Themes now properly switch based on system preference without requiring classes
- Added manual override support via data-theme attributes

## Changes
- Added `BASE_CSS_WITH_VARS` using CSS variables for all theme colors
- Created `THEME_VARS` dictionary with variable definitions for all themes
- Rewrote `StarlighterStyles()` to use CSS variables when `auto_switch=True`
- CSS variables approach is now default (`use_vars=True`)

## Test plan
✅ All tests pass (`uv run pytest`)
✅ Linting and formatting pass
✅ Manual testing confirms proper theme switching